### PR TITLE
Fix tab navigator position on Android - now properly appears on the bottom.

### DIFF
--- a/front-end/app/app.js
+++ b/front-end/app/app.js
@@ -2,10 +2,12 @@
 
 angular.module('ByPath', [
   'main'
-]);
+])
 
-angular.module('ByPath').config(['$logProvider',
-    function($logProvider) {
-        $logProvider.debugEnabled(false);
-    }
-]);
+.config(function($logProvider) {
+    $logProvider.debugEnabled(false);
+})
+
+.config(function($ionicConfigProvider) {
+    $ionicConfigProvider.tabs.position("bottom");
+});


### PR DESCRIPTION
Was previously appearing at the top of the UI in Android - added $ionicConfigProvider in app.js to set the position of the tab bar for all platforms. We can use that to add more platform-wide settings in the future.